### PR TITLE
use stable version of leptos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["gui", "web-programming"]
 
 [dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-leptos = { version = "0.6.5", features = ["csr", "nightly"] }
+leptos = { version = "0.6.5", features = ["csr"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["gui", "web-programming"]
 
 [dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-leptos = { version = "0.6.5", features = ["csr"] }
+leptos = { version = "0.6.9", features = ["csr"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["gui", "web-programming"]
 
 [dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-leptos = { version = "0.6.9", features = ["csr"] }
+leptos = { version = "0.6.9" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,19 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-mod toaster;
 mod toast;
+mod toaster;
 
 pub use crate::{
-	toaster::{
-		Toaster,
-		provide_toaster,
-		expect_toaster,
-	},
-
-	toast::{
-		ToastBuilder,
-		ToastLevel,
-		ToastPosition,
-	},
+    toast::{ToastBuilder, ToastLevel, ToastPosition},
+    toaster::{expect_toaster, provide_toaster, Toaster},
 };
+
+pub fn demo() {
+    let toaster = crate::expect_toaster();
+
+    toaster.toast(
+        crate::ToastBuilder::new("My toast message.")
+            .with_level(ToastLevel::Info)
+            .with_position(ToastPosition::TopRight),
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod toaster;
 
 pub use crate::{
     toast::{ToastBuilder, ToastLevel, ToastPosition},
-    toaster::{expect_toaster, provide_toaster, Toaster},
+    toaster::{expect_toaster, provide_toaster, provide_toaster_with_defaults, Toaster},
 };
 
 pub fn demo() {

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -5,175 +5,180 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-mod data;
 mod builder;
+mod data;
 
-use leptos::*;
-use gloo_timers::future::TimeoutFuture;
 use crate::toaster::expect_toaster;
+use gloo_timers::future::TimeoutFuture;
+use leptos::*;
 
-pub use crate::toast::data::{
-	ToastData,
-	ToastId,
-	ToastLevel,
-	ToastPosition,
-};
+pub use crate::toast::data::{ToastData, ToastId, ToastLevel, ToastPosition};
 
 /// A toast element with the supplied alert style.
 #[component]
 pub fn Toast(toast: ToastData) -> impl IntoView {
-	let animation_duration = 200;
+    let animation_duration = 200;
 
-	let slide_in_animation_name = get_slide_in_animation_name(&toast.position);
-	let slide_out_animation_name = get_slide_out_animation_name(&toast.position);
+    let slide_in_animation_name = get_slide_in_animation_name(&toast.position);
+    let slide_out_animation_name = get_slide_out_animation_name(&toast.position);
 
-	let (animation_name, set_animation_name) = create_signal(slide_in_animation_name);
+    let (animation_name, set_animation_name) = create_signal(slide_in_animation_name);
 
-	let (background_color, border_color, text_color) = get_colors(&toast.level);
-	let (initial_left, initial_right) = get_initial_positions(&toast.position);
+    let (background_color, border_color, text_color) = get_colors(&toast.level);
+    let (initial_left, initial_right) = get_initial_positions(&toast.position);
 
-	create_resource(|| (), move |()| async move {
-		let Some(expiry) = toast.expiry else {
-			return;
-		};
+    create_resource(
+        || (),
+        move |()| async move {
+            let Some(expiry) = toast.expiry else {
+                return;
+            };
 
-		TimeoutFuture::new(expiry).await;
+            TimeoutFuture::new(expiry).await;
 
-		if toast.clear_signal.get_untracked() {
-			return;
-		}
+            if toast.clear_signal.get_untracked() {
+                return;
+            }
 
-		toast.clear_signal.set(true);
-	});
+            toast.clear_signal.set(true);
+        },
+    );
 
-	create_resource(move || toast.clear_signal.get(), move |clear| async move {
-		if clear {
-			set_animation_name(slide_out_animation_name);
-			TimeoutFuture::new(animation_duration).await;
-			expect_toaster().remove(toast.id);
-		}
-	});
+    create_resource(
+        move || toast.clear_signal.get(),
+        move |clear| async move {
+            if clear {
+                set_animation_name.set(slide_out_animation_name);
+                TimeoutFuture::new(animation_duration).await;
+                expect_toaster().remove(toast.id);
+            }
+        },
+    );
 
-	let handle_click = move |_| {
-		if !toast.dismissable {
-			return;
-		}
+    let handle_click = move |_| {
+        if !toast.dismissable {
+            return;
+        }
 
-		toast.clear_signal.set(true);
-	};
+        toast.clear_signal.set(true);
+    };
 
-	view! {
-		<div
-			style:width="100%"
-			style:margin="12px 0"
-			style:padding="16px"
-			style:background-color=background_color
-			style:border="1px solid"
-			style:border-color=border_color
-			style:border-radius="4px"
-			style:position="relative"
-			style:cursor=get_cursor(toast.dismissable)
-			style:overflow="hidden"
-			style:box-sizing="border-box"
-			style:left=initial_left
-			style:right=initial_right
-			style:display="flex"
-			style:transition="transform 150ms ease-out, opacity 150ms ease-out"
-			style:transition-delay="250ms, 0s"
-			style:animation-name=animation_name
-			style:animation-duration=format!("{}ms", animation_duration)
-			style:animation-timing-function="linear"
-			style:animation-fill-mode="forwards"
-			on:click=handle_click
-		>
-			<span
-				style:color=text_color
-				style:font-size="var(--leptoaster-font-size)"
-				style:line-height="var(--leptoaster-line-height)"
-				style:font-family="var(--leptoaster-font-family)"
-				style:font-weight="var(--leptoaster-font-weight)"
-				style:display="inline-block"
-				style:max-width="100%"
-				style:text-overflow="ellipsis"
-				style:overflow="hidden"
-			>
-				{toast.message}
-			</span>
+    view! {
+        <div
+            style:width="100%"
+            style:margin="12px 0"
+            style:padding="16px"
+            style:background-color=background_color
+            style:border="1px solid"
+            style:border-color=border_color
+            style:border-radius="4px"
+            style:position="relative"
+            style:cursor=get_cursor(toast.dismissable)
+            style:overflow="hidden"
+            style:box-sizing="border-box"
+            style:left=initial_left
+            style:right=initial_right
+            style:display="flex"
+            style:transition="transform 150ms ease-out, opacity 150ms ease-out"
+            style:transition-delay="250ms, 0s"
+            style:animation-name=animation_name
+            style:animation-duration=format!("{}ms", animation_duration)
+            style:animation-timing-function="linear"
+            style:animation-fill-mode="forwards"
+            on:click=handle_click
+        >
+            <span
+                style:color=text_color
+                style:font-size="var(--leptoaster-font-size)"
+                style:line-height="var(--leptoaster-line-height)"
+                style:font-family="var(--leptoaster-font-family)"
+                style:font-weight="var(--leptoaster-font-weight)"
+                style:display="inline-block"
+                style:max-width="100%"
+                style:text-overflow="ellipsis"
+                style:overflow="hidden"
+            >
+                {toast.message}
+            </span>
 
-			<Show
-				when=move || { toast.expiry.is_some() && toast.progress }
-			>
-				<div
-					style:height="var(--leptoaster-progress-height)"
-					style:width="100%"
-					style:background-color=text_color
-					style:position="absolute"
-					style:bottom="0"
-					style:left="0"
-					style:animation-name="leptoaster-progress"
-					style:animation-duration=format!("{}ms", toast.expiry.unwrap())
-					style:animation-timing-function="linear"
-					style:animation-fill-mode="forwards"
-				/>
-			</Show>
-		</div>
-	}
+            <Show
+                when=move || { toast.expiry.is_some() && toast.progress }
+            >
+                <div
+                    style:height="var(--leptoaster-progress-height)"
+                    style:width="100%"
+                    style:background-color=text_color
+                    style:position="absolute"
+                    style:bottom="0"
+                    style:left="0"
+                    style:animation-name="leptoaster-progress"
+                    style:animation-duration=format!("{}ms", toast.expiry.unwrap())
+                    style:animation-timing-function="linear"
+                    style:animation-fill-mode="forwards"
+                />
+            </Show>
+        </div>
+    }
 }
 
 fn get_slide_in_animation_name(position: &ToastPosition) -> &'static str {
-	match position {
-		ToastPosition::TopLeft | ToastPosition::BottomLeft => "leptoaster-slide-in-left",
-		ToastPosition::TopRight | ToastPosition::BottomRight => "leptoaster-slide-in-right",
-	}
+    match position {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => "leptoaster-slide-in-left",
+        ToastPosition::TopRight | ToastPosition::BottomRight => "leptoaster-slide-in-right",
+    }
 }
 
 fn get_slide_out_animation_name(position: &ToastPosition) -> &'static str {
-	match position {
-		ToastPosition::TopLeft | ToastPosition::BottomLeft => "leptoaster-slide-out-left",
-		ToastPosition::TopRight | ToastPosition::BottomRight => "leptoaster-slide-out-right",
-	}
+    match position {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => "leptoaster-slide-out-left",
+        ToastPosition::TopRight | ToastPosition::BottomRight => "leptoaster-slide-out-right",
+    }
 }
 
 fn get_colors(level: &ToastLevel) -> (&'static str, &'static str, &'static str) {
-	match level {
-		ToastLevel::Info => (
-			"var(--leptoaster-info-background-color)",
-			"var(--leptoaster-info-border-color)",
-			"var(--leptoaster-info-text-color)",
-		),
+    match level {
+        ToastLevel::Info => (
+            "var(--leptoaster-info-background-color)",
+            "var(--leptoaster-info-border-color)",
+            "var(--leptoaster-info-text-color)",
+        ),
 
-		ToastLevel::Success => (
-			"var(--leptoaster-success-background-color)",
-			"var(--leptoaster-success-border-color)",
-			"var(--leptoaster-success-text-color)",
-		),
+        ToastLevel::Success => (
+            "var(--leptoaster-success-background-color)",
+            "var(--leptoaster-success-border-color)",
+            "var(--leptoaster-success-text-color)",
+        ),
 
-		ToastLevel::Warn => (
-			"var(--leptoaster-warn-background-color)",
-			"var(--leptoaster-warn-border-color)",
-			"var(--leptoaster-warn-text-color)",
-		),
+        ToastLevel::Warn => (
+            "var(--leptoaster-warn-background-color)",
+            "var(--leptoaster-warn-border-color)",
+            "var(--leptoaster-warn-text-color)",
+        ),
 
-		ToastLevel::Error => (
-			"var(--leptoaster-error-background-color)",
-			"var(--leptoaster-error-border-color)",
-			"var(--leptoaster-error-text-color)",
-		),
-	}
+        ToastLevel::Error => (
+            "var(--leptoaster-error-background-color)",
+            "var(--leptoaster-error-border-color)",
+            "var(--leptoaster-error-text-color)",
+        ),
+    }
 }
 
 fn get_initial_positions(position: &ToastPosition) -> (&'static str, &'static str) {
-	match position {
-		ToastPosition::TopLeft | ToastPosition::BottomLeft => ("calc((var(--leptoaster-width) + 12px * 2) * -1)", "auto"),
-		ToastPosition::TopRight | ToastPosition::BottomRight => ("auto", "calc((var(--leptoaster-width) + 12px * 2) * -1)"),
-	}
+    match position {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => {
+            ("calc((var(--leptoaster-width) + 12px * 2) * -1)", "auto")
+        }
+        ToastPosition::TopRight | ToastPosition::BottomRight => {
+            ("auto", "calc((var(--leptoaster-width) + 12px * 2) * -1)")
+        }
+    }
 }
 
 fn get_cursor(dismissable: bool) -> &'static str {
-	match dismissable {
-		true => "pointer",
-		false => "default",
-	}
+    match dismissable {
+        true => "pointer",
+        false => "default",
+    }
 }
 
 pub use crate::toast::builder::ToastBuilder;

--- a/src/toast/builder.rs
+++ b/src/toast/builder.rs
@@ -5,26 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 use leptos::*;
 
-use crate::toast::data::{
-	ToastId,
-	ToastLevel,
-	ToastPosition,
-	ToastData,
-};
+use crate::toast::data::{ToastData, ToastId, ToastLevel, ToastPosition};
 
 pub struct ToastBuilder {
-	message: String,
+    message: String,
 
-	level: ToastLevel,
+    level: ToastLevel,
 
-	dismissable: bool,
-	expiry: Option<u32>,
-	progress: bool,
+    dismissable: bool,
+    expiry: Option<u32>,
+    progress: bool,
 
-	position: ToastPosition,
+    position: ToastPosition,
 }
 
 /// Builds a toast, allowing for the custimization of toast message,
@@ -39,116 +33,116 @@ pub struct ToastBuilder {
 ///
 /// # Examples
 /// ```
-/// ToastBuilder::new("My toast message.")
-///     .with_level(ToastLevel::Success)
+/// leptoaster::ToastBuilder::new("My toast message.")
+///     .with_level(leptoaster::ToastLevel::Success)
 ///     .with_expiry(Some(2_500))
 ///     .with_progress(true)
-///     .with_position(ToastPosition::BottomLeft);
+///     .with_position(leptoaster::ToastPosition::BottomLeft);
 /// ```
 impl ToastBuilder {
-	/// Constructs a new toast builder with the supplied message.
-	///
-	/// # Examples
-	/// ```
-	/// let toast = ToastBuilder::new("My toast message.");
-	/// ```
-	#[must_use]
-	pub fn new(message: &str) -> Self {
-		ToastBuilder {
-			message: message.into(),
+    /// Constructs a new toast builder with the supplied message.
+    ///
+    /// # Examples
+    /// ```
+    /// let toast = leptoaster::ToastBuilder::new("My toast message.");
+    /// ```
+    #[must_use]
+    pub fn new(message: &str) -> Self {
+        ToastBuilder {
+            message: message.into(),
 
-			level: ToastLevel::Info,
+            level: ToastLevel::Info,
 
-			dismissable: true,
-			expiry: Some(2_500),
-			progress: true,
+            dismissable: true,
+            expiry: Some(2_500),
+            progress: true,
 
-			position: ToastPosition::BottomLeft,
-		}
-	}
+            position: ToastPosition::BottomLeft,
+        }
+    }
 
-	/// Sets the level of the toast.
-	///
-	/// # Examples
-	/// ```
-	/// ToastBuilder::new("My toast message.")
-	///     .with_level(ToastLevel::Warn); // sets the level to `warn`.
-	/// ```
-	#[must_use]
-	pub fn with_level(mut self, level: ToastLevel) -> Self {
-		self.level = level;
-		self
-	}
+    /// Sets the level of the toast.
+    ///
+    /// # Examples
+    /// ```
+    /// leptoaster::ToastBuilder::new("My toast message.")
+    ///     .with_level(leptoaster::ToastLevel::Warn); // sets the level to `warn`.
+    /// ```
+    #[must_use]
+    pub fn with_level(mut self, level: ToastLevel) -> Self {
+        self.level = level;
+        self
+    }
 
-	/// Sets the dismissable flag of the toast to allow or disallow the toast
-	/// from being dismissable on click.
-	///
-	/// # Examples
-	/// ```
-	/// ToastBuilder::new("My toast message.")
-	///     .with_dismissable(true); // allows the toast to be dismissable on click
-	/// ```
-	#[must_use]
-	pub fn with_dismissable(mut self, dismissable: bool) -> Self {
-		self.dismissable = dismissable;
-		self
-	}
+    /// Sets the dismissable flag of the toast to allow or disallow the toast
+    /// from being dismissable on click.
+    ///
+    /// # Examples
+    /// ```
+    /// leptoaster::ToastBuilder::new("My toast message.")
+    ///     .with_dismissable(true); // allows the toast to be dismissable on click
+    /// ```
+    #[must_use]
+    pub fn with_dismissable(mut self, dismissable: bool) -> Self {
+        self.dismissable = dismissable;
+        self
+    }
 
-	/// Sets the progress flag of the toast to show or hide the progress bar.
-	///
-	/// # Examples
-	/// ```
-	/// ToastBuilder::new("My toast message.")
-	///     .with_progress(true); // enables the progress bar.
-	/// ```
-	#[must_use]
-	pub fn with_progress(mut self, progress: bool) -> Self {
-		self.progress = progress;
-		self
-	}
+    /// Sets the progress flag of the toast to show or hide the progress bar.
+    ///
+    /// # Examples
+    /// ```
+    /// leptoaster::ToastBuilder::new("My toast message.")
+    ///     .with_progress(true); // enables the progress bar.
+    /// ```
+    #[must_use]
+    pub fn with_progress(mut self, progress: bool) -> Self {
+        self.progress = progress;
+        self
+    }
 
-	/// Sets the expiry time of the toast in milliseconds, or disables it on `None`.
-	///
-	/// # Examples
-	/// ```
-	/// ToastBuilder::new("My toast message.")
-	///     .with_expiry(Some(1_500)); // sets the expiry time to `1500ms`.
-	/// ```
-	#[must_use]
-	pub fn with_expiry(mut self, expiry: Option<u32>) -> Self {
-		self.expiry = expiry;
-		self
-	}
+    /// Sets the expiry time of the toast in milliseconds, or disables it on `None`.
+    ///
+    /// # Examples
+    /// ```
+    /// leptoaster::ToastBuilder::new("My toast message.")
+    ///     .with_expiry(Some(1_500)); // sets the expiry time to `1500ms`.
+    /// ```
+    #[must_use]
+    pub fn with_expiry(mut self, expiry: Option<u32>) -> Self {
+        self.expiry = expiry;
+        self
+    }
 
-	/// Sets the position of the toast.
-	///
-	/// # Examples
-	/// ```
-	/// ToastBuilder::new("My toast message.")
-	///     .with_position(ToastPosition::TopRight); // sets the position to the top right.
-	/// ```
-	#[must_use]
-	pub fn with_position(mut self, position: ToastPosition) -> Self {
-		self.position = position;
-		self
-	}
+    /// Sets the position of the toast.
+    ///
+    /// # Examples
+    /// ```
+    /// leptoaster::ToastBuilder::new("My toast message.")
+    ///     .with_position(leptoaster::ToastPosition::TopRight); // sets the position to the top right.
+    /// ```
+    #[must_use]
+    pub fn with_position(mut self, position: ToastPosition) -> Self {
+        self.position = position;
+        self
+    }
 
-	/// Builds the toast into a `ToastData` with the supplied ID.
-	#[must_use]
-	pub fn build(self, id: ToastId) -> ToastData {
-		ToastData {
-			id,
-			message: self.message,
+    /// Builds the toast into a `ToastData` with the supplied ID.
+    #[must_use]
+    pub fn build(self, id: ToastId) -> ToastData {
+        ToastData {
+            id,
+            message: self.message,
 
-			level: self.level,
+            level: self.level,
 
-			dismissable: self.dismissable,
-			expiry: self.expiry,
-			progress: self.progress,
+            dismissable: self.dismissable,
+            expiry: self.expiry,
+            progress: self.progress,
 
-			position: self.position,
+            position: self.position,
 
-			clear_signal: create_rw_signal(false),
-		}
-	}
+            clear_signal: create_rw_signal(false),
+        }
+    }
 }

--- a/src/toast/builder.rs
+++ b/src/toast/builder.rs
@@ -9,6 +9,7 @@ use leptos::*;
 
 use crate::toast::data::{ToastData, ToastId, ToastLevel, ToastPosition};
 
+#[derive(Clone, Debug)]
 pub struct ToastBuilder {
     message: String,
 
@@ -61,6 +62,10 @@ impl ToastBuilder {
         }
     }
 
+    pub(crate) fn with_message(mut self, level: impl AsRef<str>) -> Self {
+        self.message = level.as_ref().into();
+        self
+    }
     /// Sets the level of the toast.
     ///
     /// # Examples
@@ -144,5 +149,10 @@ impl ToastBuilder {
 
             clear_signal: create_rw_signal(false),
         }
+    }
+}
+impl Default for ToastBuilder {
+    fn default() -> Self {
+        ToastBuilder::new("")
     }
 }

--- a/src/toaster.rs
+++ b/src/toaster.rs
@@ -7,15 +7,15 @@
 
 pub mod context;
 
-use leptos::*;
-use crate::toaster::context::ToasterContext;
 use crate::toast::{Toast, ToastData, ToastPosition};
+use crate::toaster::context::ToasterContext;
+use leptos::*;
 
 const CONTAINER_POSITIONS: &[ToastPosition] = &[
-	ToastPosition::TopLeft,
-	ToastPosition::TopRight,
-	ToastPosition::BottomRight,
-	ToastPosition::BottomLeft,
+    ToastPosition::TopLeft,
+    ToastPosition::TopRight,
+    ToastPosition::BottomRight,
+    ToastPosition::BottomLeft,
 ];
 
 /// Creates the toaster containers as fixed-position elements on the corners of the screen.
@@ -35,15 +35,12 @@ const CONTAINER_POSITIONS: &[ToastPosition] = &[
 /// }
 /// ```
 #[component]
-pub fn Toaster(
-	#[prop(optional, into)]
-	stacked: MaybeSignal<bool>,
-) -> impl IntoView {
-	let toaster = expect_toaster();
+pub fn Toaster(#[prop(optional, into)] stacked: MaybeSignal<bool>) -> impl IntoView {
+    let toaster = expect_toaster();
 
-	view! {
-		<style>
-			"
+    view! {
+        <style>
+            "
 			:root {
 				--leptoaster-width: 320px;
 				--leptoaster-max-width: 80vw;
@@ -167,104 +164,108 @@ pub fn Toaster(
 				to { width: 0; }
 			}
 			"
-		</style>
+        </style>
 
-		<For
-			each=move || CONTAINER_POSITIONS
-			key=|position| get_container_id(position)
-			let:position
-		>
-			<Show
-				when=move || !is_container_empty(position)
-			>
-				<div
-					class=get_container_class(stacked(), position)
-					style:width="var(--leptoaster-width)"
-					style:max-width="var(--leptoaster-max-width)"
-					style:margin=get_container_margin(position)
-					style:position="fixed"
-					style:inset=get_container_inset(position)
-					style:z-index="var(--leptoaster-z-index)"
-				>
-					<For
-						each=move || {
-							let toasts = toaster.queue.get();
+        <For
+            each=move || CONTAINER_POSITIONS
+            key=|position| get_container_id(position)
+            let:position
+        >
+            <Show
+                when=move || !is_container_empty(position)
+            >
+                <div
+                    class=get_container_class(stacked.get(), position)
+                    style:width="var(--leptoaster-width)"
+                    style:max-width="var(--leptoaster-max-width)"
+                    style:margin=get_container_margin(position)
+                    style:position="fixed"
+                    style:inset=get_container_inset(position)
+                    style:z-index="var(--leptoaster-z-index)"
+                >
+                    <For
+                        each=move || {
+                            let toasts = toaster.queue.get();
 
-							match position {
-								ToastPosition::BottomLeft | ToastPosition::BottomRight => {
-									toasts.iter()
-										.filter(|toast| toast.position.eq(position)).cloned()
-										.collect::<Vec<ToastData>>()
-								},
+                            match position {
+                                ToastPosition::BottomLeft | ToastPosition::BottomRight => {
+                                    toasts.iter()
+                                        .filter(|toast| toast.position.eq(position)).cloned()
+                                        .collect::<Vec<ToastData>>()
+                                },
 
-								ToastPosition::TopLeft | ToastPosition::TopRight => {
-									toasts.iter()
-										.filter(|toast| toast.position.eq(position)).cloned()
-										.rev()
-										.collect::<Vec<ToastData>>()
-								},
-							}
-						}
-						key=|toast| toast.id
-						let:toast
-					>
-						<Toast toast={toast} />
-					</For>
-				</div>
-			</Show>
-		</For>
-	}
+                                ToastPosition::TopLeft | ToastPosition::TopRight => {
+                                    toasts.iter()
+                                        .filter(|toast| toast.position.eq(position)).cloned()
+                                        .rev()
+                                        .collect::<Vec<ToastData>>()
+                                },
+                            }
+                        }
+                        key=|toast| toast.id
+                        let:toast
+                    >
+                        <Toast toast={toast} />
+                    </For>
+                </div>
+            </Show>
+        </For>
+    }
 }
 
 pub fn provide_toaster() {
-	if use_context::<ToasterContext>().is_none() {
-		provide_context(ToasterContext::default());
-	}
+    if use_context::<ToasterContext>().is_none() {
+        provide_context(ToasterContext::default());
+    }
 }
 
 #[must_use]
 pub fn expect_toaster() -> ToasterContext {
-	expect_context::<ToasterContext>()
+    expect_context::<ToasterContext>()
 }
 
 fn is_container_empty(position: &ToastPosition) -> bool {
-	!expect_toaster().queue
-		.get().iter()
-		.any(|toast| toast.position.eq(position))
+    !expect_toaster()
+        .queue
+        .get()
+        .iter()
+        .any(|toast| toast.position.eq(position))
 }
 
 fn get_container_id(position: &ToastPosition) -> &'static str {
-	match position {
-		ToastPosition::TopLeft => "top_left",
-		ToastPosition::TopRight => "top_right",
-		ToastPosition::BottomRight => "bottom_right",
-		ToastPosition::BottomLeft => "bottom_left",
-	}
+    match position {
+        ToastPosition::TopLeft => "top_left",
+        ToastPosition::TopRight => "top_right",
+        ToastPosition::BottomRight => "bottom_right",
+        ToastPosition::BottomLeft => "bottom_left",
+    }
 }
 
 fn get_container_inset(position: &ToastPosition) -> &'static str {
-	match position {
-		ToastPosition::TopLeft => "0 auto auto 0",
-		ToastPosition::TopRight => "0 0 auto auto",
-		ToastPosition::BottomRight => "auto 0 0 auto",
-		ToastPosition::BottomLeft => "auto 0 0 0",
-	}
+    match position {
+        ToastPosition::TopLeft => "0 auto auto 0",
+        ToastPosition::TopRight => "0 0 auto auto",
+        ToastPosition::BottomRight => "auto 0 0 auto",
+        ToastPosition::BottomLeft => "auto 0 0 0",
+    }
 }
 
 fn get_container_margin(position: &ToastPosition) -> &'static str {
-	match position {
-		ToastPosition::TopLeft | ToastPosition::BottomLeft => "0 0 0 12px",
-		ToastPosition::TopRight | ToastPosition::BottomRight => "0 12px 0 0",
-	}
+    match position {
+        ToastPosition::TopLeft | ToastPosition::BottomLeft => "0 0 0 12px",
+        ToastPosition::TopRight | ToastPosition::BottomRight => "0 12px 0 0",
+    }
 }
 
 fn get_container_class(stacked: bool, position: &ToastPosition) -> Option<&'static str> {
-	if !stacked {
-		return None;
-	}
+    if !stacked {
+        return None;
+    }
 
-	match position {
-		ToastPosition::BottomLeft | ToastPosition::BottomRight => Some("leptoaster-stack-container-bottom"),
-		ToastPosition::TopLeft | ToastPosition::TopRight => Some("leptoaster-stack-container-top"),
-	}
+    match position {
+        ToastPosition::BottomLeft | ToastPosition::BottomRight => {
+            Some("leptoaster-stack-container-bottom")
+        }
+        ToastPosition::TopLeft | ToastPosition::TopRight => Some("leptoaster-stack-container-top"),
+    }
 }

--- a/src/toaster.rs
+++ b/src/toaster.rs
@@ -7,8 +7,11 @@
 
 pub mod context;
 
-use crate::toast::{Toast, ToastData, ToastPosition};
 use crate::toaster::context::ToasterContext;
+use crate::{
+    toast::{Toast, ToastData, ToastPosition},
+    ToastBuilder,
+};
 use leptos::*;
 
 const CONTAINER_POSITIONS: &[ToastPosition] = &[
@@ -216,6 +219,17 @@ pub fn Toaster(#[prop(optional, into)] stacked: MaybeSignal<bool>) -> impl IntoV
 pub fn provide_toaster() {
     if use_context::<ToasterContext>().is_none() {
         provide_context(ToasterContext::default());
+    }
+}
+/// Provides the toaster context with the supplied defaults.
+/// Example:
+/// ```ignore
+/// use leptoaster::*;
+/// provide_toaster_with_defaults(ToastBuilder::default().with_position(ToastPosition::TopRight));
+/// ```
+pub fn provide_toaster_with_defaults(defaults: ToastBuilder) {
+    if use_context::<ToasterContext>().is_none() {
+        provide_context(ToasterContext::new_with_defaults(defaults));
     }
 }
 

--- a/src/toaster/context.rs
+++ b/src/toaster/context.rs
@@ -5,186 +5,168 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::{
-	rc::Rc,
-	cell::RefCell,
-};
+use std::{cell::RefCell, rc::Rc};
 
 use leptos::*;
 
-use crate::toast::{
-	ToastBuilder,
-	ToastData,
-	ToastId,
-	ToastLevel,
-};
+use crate::toast::{ToastBuilder, ToastData, ToastId, ToastLevel};
 
 /// The global context of the toaster. You should provide this as a global context
 /// in your root component to allow any component in your application to toast
 /// using the same toast queue.
 ///
 ///  # Examples
-///  ```
-///  #[component]
-///  fn App() -> impl IntoView {
-///      provide_context(ToasterContext::default());
+/// ```
+///  #[leptos::component]
+///  fn App() -> impl leptos::IntoView {
+///      leptoaster::provide_toaster();
 ///  }
 ///  ```
 #[derive(Clone, Debug)]
 pub struct ToasterContext {
-	stats: Rc<RefCell<ToasterStats>>,
-	pub queue: RwSignal<Vec<ToastData>>,
+    stats: Rc<RefCell<ToasterStats>>,
+    pub queue: RwSignal<Vec<ToastData>>,
 }
 
 #[derive(Clone, Default, Debug)]
 struct ToasterStats {
-	visible: u32,
-	total: u64,
+    visible: u32,
+    total: u64,
 }
 
 impl ToasterContext {
-	/// Adds the supplied toast to the toast queue, displaying it onto the screen.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///
-	///     toaster.toast(
-	///         ToastBuilder::new("My toast message.")
-	///             .with_expiry(1_500)
-	///     );
-	/// }
-	/// ```
-	pub fn toast(&self, builder: ToastBuilder) {
-		let toast = builder.build(self.stats.borrow().total + 1);
+    /// Adds the supplied toast to the toast queue, displaying it onto the screen.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///
+    ///     toaster.toast(
+    ///         leptoaster::ToastBuilder::new("My toast message.")
+    ///             .with_expiry(1_500.into())
+    ///     );
+    /// }
+    /// ```
+    pub fn toast(&self, builder: ToastBuilder) {
+        let toast = builder.build(self.stats.borrow().total + 1);
 
-		let mut queue = self.queue.get_untracked();
-		queue.push(toast);
-		self.queue.set(queue);
+        let mut queue = self.queue.get_untracked();
+        queue.push(toast);
+        self.queue.set(queue);
 
-		self.stats.borrow_mut().visible += 1;
-		self.stats.borrow_mut().total += 1;
-	}
+        self.stats.borrow_mut().visible += 1;
+        self.stats.borrow_mut().total += 1;
+    }
 
-	/// Quickly display an `info` toast with default parameters. For more customization,
-	/// use the `toast` function.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///     toaster.info("My toast message.");
-	/// }
-	/// ```
-	pub fn info(&self, message: &str) {
-		self.toast(
-			ToastBuilder::new(message)
-				.with_level(ToastLevel::Info)
-		);
-	}
+    /// Quickly display an `info` toast with default parameters. For more customization,
+    /// use the `toast` function.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///     toaster.info("My toast message.");
+    /// }
+    /// ```
+    pub fn info(&self, message: &str) {
+        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Info));
+    }
 
-	/// Quickly display a `success` toast with default parameters. For more customization,
-	/// use the `toast` function.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///     toaster.success("My toast message.");
-	/// }
-	/// ```
-	pub fn success(&self, message: &str) {
-		self.toast(
-			ToastBuilder::new(message)
-				.with_level(ToastLevel::Success)
-		);
-	}
+    /// Quickly display a `success` toast with default parameters. For more customization,
+    /// use the `toast` function.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///     toaster.success("My toast message.");
+    /// }
+    /// ```
+    pub fn success(&self, message: &str) {
+        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Success));
+    }
 
-	/// Quickly display a `warn` toast with default parameters. For more customization,
-	/// use the `toast` function.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///     toaster.warn("My toast message.");
-	/// }
-	/// ```
-	pub fn warn(&self, message: &str) {
-		self.toast(
-			ToastBuilder::new(message)
-				.with_level(ToastLevel::Warn)
-		);
-	}
+    /// Quickly display a `warn` toast with default parameters. For more customization,
+    /// use the `toast` function.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///     toaster.warn("My toast message.");
+    /// }
+    /// ```
+    pub fn warn(&self, message: &str) {
+        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Warn));
+    }
 
-	/// Quickly display an `error` toast with default parameters. For more customization,
-	/// use the `toast` function.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///     toaster.error("My toast message.");
-	/// }
-	/// ```
-	pub fn error(&self, message: &str) {
-		self.toast(
-			ToastBuilder::new(message)
-				.with_level(ToastLevel::Error)
-		);
-	}
+    /// Quickly display an `error` toast with default parameters. For more customization,
+    /// use the `toast` function.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///     toaster.error("My toast message.");
+    /// }
+    /// ```
+    pub fn error(&self, message: &str) {
+        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Error));
+    }
 
-	/// Clears all currently visible toasts.
-	///
-	/// # Examples
-	/// ```
-	/// #[component]
-	/// fn Component() -> impl IntoView {
-	///     let toaster = expect_context::<ToasterContext>();
-	///
-	///     toaster.toast(
-	///         ToastBuilder::new("My toast message.")
-	///             .with_expiry(None) // the toast will not self-expire
-	///     );
-	///
-	///     toaster.clear();
-	/// }
-	/// ```
-	pub fn clear(&self) {
-		for toast in &self.queue.get_untracked() {
-			toast.clear_signal.set(true);
-		}
-	}
+    /// Clears all currently visible toasts.
+    ///
+    /// # Examples
+    /// ```
+    /// #[leptos::component]
+    /// fn Component() -> impl leptos::IntoView {
+    ///     let toaster = leptoaster::expect_toaster();
+    ///
+    ///     toaster.toast(
+    ///         leptoaster::ToastBuilder::new("My toast message.")
+    ///             .with_expiry(None) // the toast will not self-expire
+    ///     );
+    ///
+    ///     toaster.clear();
+    /// }
+    /// ```
+    pub fn clear(&self) {
+        for toast in &self.queue.get_untracked() {
+            toast.clear_signal.set(true);
+        }
+    }
 
-	/// Removes the toast corresponding with the supplied `ToastId`.
-	pub fn remove(&self, toast_id: ToastId) {
-		let index = self.queue
-			.get_untracked()
-			.iter().enumerate()
-			.find(|(_, toast)| toast.id == toast_id)
-			.map(|(index, _)| index);
+    /// Removes the toast corresponding with the supplied `ToastId`.
+    pub fn remove(&self, toast_id: ToastId) {
+        let index = self
+            .queue
+            .get_untracked()
+            .iter()
+            .enumerate()
+            .find(|(_, toast)| toast.id == toast_id)
+            .map(|(index, _)| index);
 
-		if let Some(index) = index {
-			let mut queue = self.queue.get_untracked();
-			queue.remove(index);
-			self.queue.set(queue);
+        if let Some(index) = index {
+            let mut queue = self.queue.get_untracked();
+            queue.remove(index);
+            self.queue.set(queue);
 
-			self.stats.borrow_mut().visible -= 1;
-		}
-	}
+            self.stats.borrow_mut().visible -= 1;
+        }
+    }
 }
 
 impl Default for ToasterContext {
-	fn default() -> Self {
-		ToasterContext {
-			stats: Rc::new(RefCell::new(ToasterStats::default())),
-			queue: create_rw_signal(Vec::new()),
-		}
-	}
+    fn default() -> Self {
+        ToasterContext {
+            stats: Rc::new(RefCell::new(ToasterStats::default())),
+            queue: create_rw_signal(Vec::new()),
+        }
+    }
 }

--- a/src/toaster/context.rs
+++ b/src/toaster/context.rs
@@ -26,6 +26,7 @@ use crate::toast::{ToastBuilder, ToastData, ToastId, ToastLevel};
 pub struct ToasterContext {
     stats: Rc<RefCell<ToasterStats>>,
     pub queue: RwSignal<Vec<ToastData>>,
+    defaults: Option<ToastBuilder>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -35,6 +36,13 @@ struct ToasterStats {
 }
 
 impl ToasterContext {
+    pub(crate) fn new_with_defaults(defaults: ToastBuilder) -> Self {
+        ToasterContext {
+            stats: Rc::new(RefCell::new(ToasterStats::default())),
+            queue: create_rw_signal(Vec::new()),
+            defaults: Some(defaults),
+        }
+    }
     /// Adds the supplied toast to the toast queue, displaying it onto the screen.
     ///
     /// # Examples
@@ -72,7 +80,14 @@ impl ToasterContext {
     /// }
     /// ```
     pub fn info(&self, message: &str) {
-        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Info));
+        self.toast(
+            self.defaults
+                .as_ref()
+                .map(|defaults| defaults.clone().with_message(message))
+                .unwrap_or_else(|| ToastBuilder::new(message))
+                .with_level(ToastLevel::Info),
+        );
+        // ToastBuilder::new(message).with_level(ToastLevel::Info));
     }
 
     /// Quickly display a `success` toast with default parameters. For more customization,
@@ -87,7 +102,13 @@ impl ToasterContext {
     /// }
     /// ```
     pub fn success(&self, message: &str) {
-        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Success));
+        self.toast(
+            self.defaults
+                .as_ref()
+                .map(|defaults| defaults.clone().with_message(message))
+                .unwrap_or_else(|| ToastBuilder::new(message))
+                .with_level(ToastLevel::Success),
+        );
     }
 
     /// Quickly display a `warn` toast with default parameters. For more customization,
@@ -102,7 +123,13 @@ impl ToasterContext {
     /// }
     /// ```
     pub fn warn(&self, message: &str) {
-        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Warn));
+        self.toast(
+            self.defaults
+                .as_ref()
+                .map(|defaults| defaults.clone().with_message(message))
+                .unwrap_or_else(|| ToastBuilder::new(message))
+                .with_level(ToastLevel::Warn),
+        );
     }
 
     /// Quickly display an `error` toast with default parameters. For more customization,
@@ -117,7 +144,13 @@ impl ToasterContext {
     /// }
     /// ```
     pub fn error(&self, message: &str) {
-        self.toast(ToastBuilder::new(message).with_level(ToastLevel::Error));
+        self.toast(
+            self.defaults
+                .as_ref()
+                .map(|defaults| defaults.clone().with_message(message))
+                .unwrap_or_else(|| ToastBuilder::new(message))
+                .with_level(ToastLevel::Error),
+        );
     }
 
     /// Clears all currently visible toasts.
@@ -167,6 +200,7 @@ impl Default for ToasterContext {
         ToasterContext {
             stats: Rc::new(RefCell::new(ToasterStats::default())),
             queue: create_rw_signal(Vec::new()),
+            defaults: None,
         }
     }
 }


### PR DESCRIPTION
Instead of using nightly this can be compiled using stable rust versions whilst still being able to be used with nightly as well without loosing any functionality.
Also fixed failing doc-tests and run rustfmt on codebase