### PR TITLE
Refactor: remove leptos nightly feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["leptos", "toast", "web", "ui", "userinterface"]
 categories = ["gui", "web-programming"]
 
 [dependencies]
-gloo-timers = { version = "0.3.0", features = ["futures"] }
-leptos = { version = "0.6.5", features = ["csr", "nightly"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+leptos = { version = "0.6", features = ["csr"] }

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -48,7 +48,7 @@ pub fn Toast(toast: ToastData) -> impl IntoView {
 
 	create_resource(move || toast.clear_signal.get(), move |clear| async move {
 		if clear {
-			set_animation_name(slide_out_animation_name);
+			set_animation_name.set(slide_out_animation_name);
 			TimeoutFuture::new(animation_duration).await;
 			expect_toaster().remove(toast.id);
 		}

--- a/src/toaster.rs
+++ b/src/toaster.rs
@@ -178,7 +178,7 @@ pub fn Toaster(
 				when=move || !is_container_empty(position)
 			>
 				<div
-					class=get_container_class(stacked(), position)
+					class=get_container_class(stacked.get(), position)
 					style:width="var(--leptoaster-width)"
 					style:max-width="var(--leptoaster-max-width)"
 					style:margin=get_container_margin(position)


### PR DESCRIPTION
Hi,
I want to use your library in my project (https://github.com/TheBestTvarynka/Dataans). It is minimalistic and has all the functionality I need, which makes it perfect for my case.

Unfortunately, I found out that this crate can be built only with nightly rust. I removed this restriction.

If you did it on purpose or don't want to accept my changes, feel free to close this PR :innocent: